### PR TITLE
Fix to allow applying the plugin multiple times to same element

### DIFF
--- a/jquery.checktree.js
+++ b/jquery.checktree.js
@@ -41,6 +41,9 @@ jQuery.fn.checkTree = function(settings) {
     var $lis = $tree.find('li');
     var $checkboxes = $lis.find(":checkbox");
 
+    //remove all divs to avoid issues if it already has created the elements
+    $tree.find('div').remove();
+
     // Hide all checkbox inputs
     $checkboxes.css('display', 'none');
 

--- a/jquery.checktree.js
+++ b/jquery.checktree.js
@@ -42,14 +42,14 @@ jQuery.fn.checkTree = function(settings) {
     var $checkboxes = $lis.find(":checkbox");
 
     //remove all divs to avoid issues if it already has created the elements
-    $tree.find('div').remove();
+    $tree.find('div.checktree').remove();
 
     // Hide all checkbox inputs
     $checkboxes.css('display', 'none');
 
     $lis.not(':has(.arrow)').each(function() {
         // This little piece here is by far the slowest.
-        jQuery(this).prepend('<div class="arrow"></div><div class="checkbox"></div>');
+        jQuery(this).prepend('<div class="checktree arrow"></div><div class="checktree checkbox"></div>');
     });
 
     /*


### PR DESCRIPTION
After applying the plugin to an element, some divs are created inside the list.

If you try to apply again the plugin to an element, it stop working. When you click on the "checkboxes" nothing happens. Also, the sub-lists disappear.

This PR fixes that by just removing the <divs> that the plugin create, before attempting to create them again.